### PR TITLE
Add Vercel analytics and HeroSlider fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-email/components": "^1.0.8",
         "@react-email/render": "^2.0.4",
         "@svgr/webpack": "^8.1.0",
+        "@vercel/analytics": "^1.6.1",
         "clsx": "^2.1.1",
         "next": "16.1.6",
         "nodemailer": "^8.0.1",
@@ -4274,6 +4275,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@react-email/components": "^1.0.8",
     "@react-email/render": "^2.0.4",
     "@svgr/webpack": "^8.1.0",
+    "@vercel/analytics": "^1.6.1",
     "clsx": "^2.1.1",
     "next": "16.1.6",
     "nodemailer": "^8.0.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import SEOJsonLd from "@/utils/SEOJsonLd";
 import { Toaster } from "sonner";
 import ButtonScrollToTop from "@/components/ButtonScrollToTop";
 import { Analytics } from "@/components/Analytics";
+import { Analytics as VercelAnalytics } from "@vercel/analytics/next";
 import VideoIntroduction from "@/components/VideoIntroduction";
 
 const cormorantGaramond = Cormorant_Garamond({
@@ -86,7 +87,7 @@ export default function RootLayout({
           <Toaster richColors />
         </Suspense>
         <Analytics />
-
+        <VercelAnalytics />
         <div className="fixed right-4 bottom-[34px] z-[10000] md:right-10">
           <Suspense fallback={null}>
             <VideoIntroduction />

--- a/src/components/HomePage/HeroSection/HeroSection.tsx
+++ b/src/components/HomePage/HeroSection/HeroSection.tsx
@@ -3,11 +3,27 @@ import WhatsAppLink from "../../common/Links/WhatsAppLink";
 import Container from "../../common/Container";
 import HeroSlider from "./Slider";
 
+function HeroSliderFallback() {
+  return (
+    <div aria-hidden className="pb-7">
+      <div className="relative h-[680px] overflow-hidden rounded-4xl md:max-h-[80vh]">
+        <div className="absolute inset-0 bg-main_blue" />
+        <div className="absolute inset-0 bg-linear-to-br from-main_blue via-main_blue/90 to-main_blue/70" />
+      </div>
+      <div className="mt-4 flex items-center justify-center gap-1.5">
+        <span className="h-1.5 w-5 rounded-full bg-yellow_main/80" />
+        <span className="h-1.5 w-1.5 rounded-full bg-white/60" />
+        <span className="h-1.5 w-1.5 rounded-full bg-white/60" />
+      </div>
+    </div>
+  );
+}
+
 function HeroSection() {
   return (
     <section className="py-10 md:py-16 xl:py-0 xl:pt-5 xl:pb-20">
       <Container className="relative">
-        <Suspense fallback={null}>
+        <Suspense fallback={<HeroSliderFallback />}>
           <HeroSlider />
         </Suspense>
         <WhatsAppLink


### PR DESCRIPTION
Install @vercel/analytics and wire VercelAnalytics into RootLayout to enable analytics. Add a HeroSliderFallback component and use it as the Suspense fallback for HeroSlider to show a placeholder UI while the slider loads. package.json and package-lock.json updated to include the new dependency.